### PR TITLE
Allow Users to toggle return value of `notify`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## v1.1.0 / 2021 Oct 19
+## v1.1.0 / 2021 Oct 21
 
-> This release adds the `:return-bugsnag-response?` option to `notify` to make behavior more consistent with other logging interfaces
+> This release adds the `:suppress-bugsnag-response?` option to `notify` to make behavior more consistent with other logging interfaces
 
 ## v1.0.0 / 2021 Oct 19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
-## v1.0.0 / 202x MMM DD
+## v1.1.0 / 2021 Oct 19
+
+> This release adds the `:return-bugsnag-response?` option to `notify` to make behavior more consistent with other logging interfaces
+
+## v1.0.0 / 2021 Oct 19
 
 > This release officially forks com.splashfinancial/clj-bugsnag from the original project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v1.1.0 / 2021 Oct 21
 
 > This release adds the `:suppress-bugsnag-response?` option to `notify` to make behavior more consistent with other logging interfaces
+> Additionally include a `notify-v2!` which surpresses this output by default
 
 ## v1.0.0 / 2021 Oct 19
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ Alternatively, you may clone or fork the repository to work with it directly.
 
     ;; If no api-key is provided, clj-bugsnag will fall back to BUGSNAG_KEY environment variable and bugsnagKey system property
     (bugsnag/notify exception)
+
+    ;; Alternatively, if you do not want the HTTP response from Bugsnag
+    ;; This function may be supplied the same map of options as well, but ignores `:suppress-bugsnag-response?`
+    (bugsnag/notify-v2! exception)
 ```
 
 By default, `notify` will return the HTTP response from Bugsnag.

--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ Definitions of all option map keys are below:
 - `:project-ns` - The BugSnag project name you'd like to report the error to.
   Typically the artifact name.
   Defaults to \000
-- `:context` - The BugSnag 'context' in which an error occured.
+- `:context` - The BugSnag 'context' in which an error occurred.
   Defaults to nil.
   See [Bugsnag's documentation](https://docs.bugsnag.com/platforms/java/other/customizing-error-reports/) for more details
-- `:group` - The BugSnag 'group' an error occured within.
+- `:group` - The BugSnag 'group' an error occurred within.
   Defaults to the exception message for instances of `clojure.lang.ExceptionInfo` or the Class Name of the Exception
 - `:severity` - The severity of the error.
   Must be one of `info`, `warning`, and `error`.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Alternatively, you may clone or fork the repository to work with it directly.
        :environment "dev"
        :version "v1.2.3"
        :severity "error"
-       :return-bugsnag-response? true
+       :suppress-bugsnag-response? true
        ;; Attach custom metadata to create tabs in Bugsnag:
        :meta {:input some-input}
        ;; Pass a user object to Bugsnag for better stats
@@ -82,8 +82,8 @@ Alternatively, you may clone or fork the repository to work with it directly.
     (bugsnag/notify exception)
 ```
 
-By default, `notify` will return nil and fire the side-effect of logging to Bugsnag.
-If you'd like access to the `clj-http` response from Bugsnag, you may set the `:return-bugsnag-response?` key in the option map to any truthy value.
+By default, `notify` will return the HTTP response from Bugsnag.
+If you'd like to simply receive nil, as is the case with most common logging interfaces, you may set the `:suppress-bugsnag-response?` key in the option map to any truthy value.
 
 Definitions of all option map keys are below:
 
@@ -109,9 +109,9 @@ Definitions of all option map keys are below:
 - `:environment` - The deployment context in which the error occurred.
   Defaults to `Production`
 - `:meta` - A map of arbitrary metadata to associate to the error
-- `:return-bugsnag-response?` - A boolean toggle for this function's return value.
-  When truthy, return the clj-http response from calling BugSnag's API
-  When falsy, return nil- consistent with other logging interfaces and `println`
+- `:suppress-bugsnag-response?` - A boolean toggle for this function's return value.
+  When falsy, return the clj-http response from calling BugSnag's API
+  When truthy, return nil- consistent with other logging interfaces and `println`
   Defaults to falsy.
 
 ## License

--- a/project.clj
+++ b/project.clj
@@ -8,4 +8,5 @@
                  [clj-stacktrace "0.2.8"]
                  [clj-http "2.0.0"]
                  [cheshire "5.5.0"]]
-  :profiles {:dev {:dependencies [[circleci/bond "0.6.0"]]}})
+  :profiles {:dev {:dependencies [[circleci/bond "0.6.0"]
+                                  [clj-http-fake "1.0.3"]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.splashfinancial/clj-bugsnag "1.0.0"
+(defproject com.splashfinancial/clj-bugsnag "1.1.0"
   :description "Fully fledged Bugsnag client. Supports ex-data and ring middleware."
   :url "https://github.com/SplashFinancial/clj-bugsnag"
   :license {:name "Eclipse Public License"

--- a/src/clj_bugsnag/core.clj
+++ b/src/clj_bugsnag/core.clj
@@ -96,7 +96,7 @@
 
 (defn notify
   "Post an `exception` to BugSnag.
-   A second, optional argument may be passed to congifugre the behavior of the client.
+   A second, optional argument may be passed to configure the behavior of the client.
    This map supports the following options.
      - :api-key - The BugSnag API key for your project.
                   If this key is missing, the library will attempt to load the Environment variable `BUGSNAG_KEY` and the JVM Property `bugsnagKey` in this order.

--- a/src/clj_bugsnag/core.clj
+++ b/src/clj_bugsnag/core.clj
@@ -104,10 +104,10 @@
      - :project-ns - The BugSnag project name you'd like to report the error to.
                      Typically the artifact name.
                      Defaults to \000
-     - :context - The BugSnag 'context' in which an error occured.
+     - :context - The BugSnag 'context' in which an error occurred.
                   Defaults to nil.
                   See https://docs.bugsnag.com/platforms/java/other/customizing-error-reports/ for more details
-     - :group - The BugSnag 'group' an error occured within.
+     - :group - The BugSnag 'group' an error occurred within.
                 Defaults to the exception message for instances of `clojure.lang.ExceptionInfo` or the Class Name of the Exception
      - :severity - The severity of the error.
                    Must be one of `info`, `warning`, and `error`.

--- a/src/clj_bugsnag/core.clj
+++ b/src/clj_bugsnag/core.clj
@@ -31,7 +31,7 @@
           source (repl/source-fn fn-sym)
           start (-> fn-var meta :line)
           indexed-lines (map-indexed (fn [i line]
-                                        [(+ i start) (string/trimr line)])
+                                       [(+ i start) (string/trimr line)])
                                      (string/split-lines source))]
       (into {} (filter #(<= (- around 3) (first %) (+ around 3)) indexed-lines)))
     (catch Exception _ex
@@ -45,11 +45,11 @@
                      method (method-str elem)
                      code (when (string/ends-with? (or file "") ".clj")
                             (find-source-snippet line (string/replace (or method "") "[fn]" "")))]]
-            {:file file
-             :lineNumber line
-             :method method
-             :inProject project?
-             :code code}))
+           {:file file
+            :lineNumber line
+            :method method
+            :inProject project?
+            :code code}))
     (catch Exception ex
       [{:file "clj-bugsnag/core.clj"
         :lineNumber 1
@@ -79,7 +79,7 @@
                             class-name))]
     {:apiKey   api-key
      :notifier {:name    "com.splashfinancial/clj-bugsnag"
-                :version "1.0.0"
+                :version "1.1.0"
                 :url     "https://github.com/SplashFinancial/clj-bugsnag"}
      :events   [{:payloadVersion "2"
                  :exceptions     [{:errorClass class-name
@@ -120,18 +120,18 @@
      - :environment - The deployment context in which the error occurred.
                       Defaults to `Production`
      - :meta - A map of arbitrary metadata to associate to the error
-     - :return-bugsnag-response? - A boolean toggle for this function's return value.
-                                   When truthy, return the clj-http response from calling BugSnag's API
-                                   When falsy, return nil- consistent with other logging interfaces and `println`
-                                   Defaults to falsy."
+     - :suppress-bugsnag-response? - A boolean toggle for this function's return value.
+                                     When truthy, return nil- consistent with other logging interfaces and `println`
+                                     When falsy, return the clj-http response from calling BugSnag's API
+                                     Defaults to falsy."
   ([exception]
    (notify exception nil))
 
-  ([exception {:keys [return-bugsnag-response?]
+  ([exception {:keys [suppress-bugsnag-response?]
                :as   options}]
    (let [params (exception->json exception options)
          url    "https://notify.bugsnag.com/"
          resp   (http/post url {:form-params  params :content-type :json})]
-     (if return-bugsnag-response?
-       resp
-       nil))))
+     (if suppress-bugsnag-response?
+       nil
+       resp))))

--- a/src/clj_bugsnag/core.clj
+++ b/src/clj_bugsnag/core.clj
@@ -95,7 +95,8 @@
                  :metaData       (walk/postwalk stringify (merge base-meta meta))}]}))
 
 (defn notify
-  "Post an `exception` to BugSnag.
+  "Notify Bugsnag about the supplied `exception`.
+   By default, this function returns the HTTP response from Bugsnag.
    A second, optional argument may be passed to configure the behavior of the client.
    This map supports the following options.
      - :api-key - The BugSnag API key for your project.
@@ -135,3 +136,40 @@
      (if suppress-bugsnag-response?
        nil
        resp))))
+
+(defn notify-v2!
+  "Notify BugSnag about the supplied `exception`.
+   By default, this function returns nil.
+   A second, optional argument may be passed to configure the behavior of the client, which deviates in behavior from `notify`
+   This map supports the following options.
+     - :api-key - The BugSnag API key for your project.
+                  If this key is missing, the library will attempt to load the Environment variable `BUGSNAG_KEY` and the JVM Property `bugsnagKey` in this order.
+                  If all three values are nil, an exception will be thrown
+     - :project-ns - The BugSnag project name you'd like to report the error to.
+                     Typically the artifact name.
+                     Defaults to \000
+     - :context - The BugSnag 'context' in which an error occurred.
+                  Defaults to nil.
+                  See https://docs.bugsnag.com/platforms/java/other/customizing-error-reports/ for more details
+     - :group - The BugSnag 'group' an error occurred within.
+                Defaults to the exception message for instances of `clojure.lang.ExceptionInfo` or the Class Name of the Exception
+     - :severity - The severity of the error.
+                   Must be one of `info`, `warning`, and `error`.
+                   Defaults to `error`
+     - :user  - A string or map of facets representing the active end user when the error occurred.
+                Defaults to nil
+     - :version - The application version running when the error was reported.
+                  Defaults to the git SHA when possible.
+                  Otherwise nil.
+     - :environment - The deployment context in which the error occurred.
+                      Defaults to `Production`
+     - :meta - A map of arbitrary metadata to associate to the error"
+  ([exception]
+   (notify-v2! exception nil))
+
+  ([exception options]
+   (let [params (exception->json exception options)
+         url    "https://notify.bugsnag.com/"
+         _      (http/post url {:form-params  params
+                                :content-type :json})]
+     nil)))

--- a/src/clj_bugsnag/core.clj
+++ b/src/clj_bugsnag/core.clj
@@ -112,26 +112,26 @@
      - :severity - The severity of the error.
                    Must be one of `info`, `warning`, and `error`.
                    Defaults to `error`
-     - :user  - A string representing the end user when the error occured.
+     - :user  - A string or map of facets representing the active end user when the error occurred.
                 Defaults to nil
      - :version - The application version running when the error was reported.
                   Defaults to the git SHA when possible.
                   Otherwise nil.
-     - :environment - The deployment context in which the error occured.
+     - :environment - The deployment context in which the error occurred.
                       Defaults to `Production`
      - :meta - A map of arbitrary metadata to associate to the error
-     - :return-bugsnag-reponse? - A boolean toggle for this function's return value.
-                                  When truthy, return the clj-http response from calling BugSnag's API
-                                  When falsy, return nil- consistent with other logging interfaces and `println`
-                                  Defaults to falsy."
+     - :return-bugsnag-response? - A boolean toggle for this function's return value.
+                                   When truthy, return the clj-http response from calling BugSnag's API
+                                   When falsy, return nil- consistent with other logging interfaces and `println`
+                                   Defaults to falsy."
   ([exception]
    (notify exception nil))
 
-  ([exception {:keys [return-bugsnag-reponse?]
+  ([exception {:keys [return-bugsnag-response?]
                :as   options}]
    (let [params (exception->json exception options)
          url    "https://notify.bugsnag.com/"
          resp   (http/post url {:form-params  params :content-type :json})]
-     (if return-bugsnag-reponse?
+     (if return-bugsnag-response?
        resp
        nil))))

--- a/test/clj_bugsnag/core_test.clj
+++ b/test/clj_bugsnag/core_test.clj
@@ -58,10 +58,10 @@
                          :body                  "OK"
                          :trace-redirects       ["https://notify.bugsnag.com/"]
                          :orig-content-encoding nil}
-        sample-client {:api-key "my-api-key" :return-bugsnag-response? true}]
+        sample-client {:api-key "my-api-key"}]
     (with-fake-routes-in-isolation
         {"https://notify.bugsnag.com/" (fn [_] sample-response)}
       (t/is (= sample-response (dissoc (core/notify test-excepiton sample-client) :request-time)))
       (bond/with-spy [clj-http.client/post]
-        (t/is (nil? (core/notify test-excepiton (dissoc sample-client :return-bugsnag-response?))))
+        (t/is (nil? (core/notify test-excepiton (assoc sample-client :suppress-bugsnag-response? true))))
         (t/is (= 1 (-> clj-http.client/post bond/calls count)))))))

--- a/test/clj_bugsnag/core_test.clj
+++ b/test/clj_bugsnag/core_test.clj
@@ -61,7 +61,7 @@
         sample-client {:api-key "my-api-key"}]
     (with-fake-routes-in-isolation
         {"https://notify.bugsnag.com/" (fn [_] sample-response)}
-      (t/is (= sample-response (dissoc (core/notify test-excepiton sample-client) :request-time)))
+      (t/is (= sample-response (dissoc (core/notify test-exception sample-client) :request-time)))
       (bond/with-spy [clj-http.client/post]
-        (t/is (nil? (core/notify test-excepiton (assoc sample-client :suppress-bugsnag-response? true))))
+        (t/is (nil? (core/notify test-exception (assoc sample-client :suppress-bugsnag-response? true))))
         (t/is (= 1 (-> clj-http.client/post bond/calls count)))))))

--- a/test/clj_bugsnag/core_test.clj
+++ b/test/clj_bugsnag/core_test.clj
@@ -45,7 +45,7 @@
                   18 "    (closure)))"}))))))
 
 (t/deftest notify-test
-  (let [test-excepiton (Exception. "Oh no!")
+  (let [test-exception (Exception. "Oh no!")
         sample-response {:status                200
                          :headers               {"Access-Control-Allow-Origin" "*"
                                                  "Bugsnag-Event-Id"            "some-event-id"


### PR DESCRIPTION
Changes proposed in this merge request:

- Additions: A `:return-bugsnag-response?` key in `notify`'s option map
- Updates: By default, return nil when notifying bugsnag
- Deletions: N/A

### Pre-merge Checklist

- [x] Write + run tests
- [x] Update CHANGELOG and increment version

Addresses: https://github.com/SplashFinancial/clj-bugsnag/issues/5